### PR TITLE
Fix ATMI build on Arch Linux: add rsync to pre-reqs for ATMI build

### DIFF
--- a/distro_install_scripts/Arch/component_scripts/01_12_atmi.sh
+++ b/distro_install_scripts/Arch/component_scripts/01_12_atmi.sh
@@ -32,7 +32,7 @@ parse_args "$@"
 if [ ${ROCM_LOCAL_INSTALL} = false ] || [ ${ROCM_INSTALL_PREREQS} = true ]; then
     echo "Installing software required to build ATMI."
     echo "You will need to have root privileges to do this."
-    sudo pacman -Sy --noconfirm --needed base-devel cmake pkgconf git
+    sudo pacman -Sy --noconfirm --needed base-devel cmake pkgconf git rsync
     if [ ${ROCM_INSTALL_PREREQS} = true ] && [ ${ROCM_FORCE_GET_CODE} = false ]; then
         exit 0
     fi


### PR DESCRIPTION
All other scripts work great on my Arch installation, but the ATMI build fails when it tries to look for "rsync" package. I think Ubuntu comes with rsync pre-installed and is thus not a requirement. Adding "rsync" to the pre-reqs fixes the build on my system.

The ATMI build looks for rsync package, which if not installed, produces the following errors:

Scanning dependencies of target device_header
[  4%] Generating device_rt.gfx906.ll
[  4%] Generating device_rt.gfx701.ll
[  6%] Generating device_rt.gfx801.ll
[  8%] Generating device_rt.gfx803.ll
[ 10%] Generating device_rt.gfx802.ll
[ 13%] Generating bin
[ 15%] Generating device_rt.gfx900.ll
make[2]: /usr/bin/rsync: Command not found
make[2]: *** [CMakeFiles/script.dir/build.make:61: bin] Error 127
[ 17%] Generating examples
make[1]: *** [CMakeFiles/Makefile2:73: CMakeFiles/script.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
make[2]: /usr/bin/rsync: Command not found
[ 19%] Generating ../../include/atmi_runtime.h
make[2]: *** [CMakeFiles/example.dir/build.make:61: examples] Error 127
make[1]: *** [CMakeFiles/Makefile2:110: CMakeFiles/example.dir/all] Error 2
[ 23%] Generating ../../include/atmi.h
[ 23%] Generating ../../../include/atmi_interop_hsa.h
[ 26%] Generating ../include/atmi_kl.h
/bin/sh: /usr/bin/rsync: No such file or directory
make[2]: *** [runtime/core/CMakeFiles/core_header.dir/build.make:66: include/atmi_runtime.h] Error 127
make[2]: *** Waiting for unfinished jobs....
[ 28%] Building C object runtime/core/CMakeFiles/atmi_runtime.dir/atl_cputask.c.o
/bin/sh: /usr/bin/rsync: No such file or directory
make[2]: *** [runtime/interop/hsa/CMakeFiles/interop_header.dir/build.make:61: include/atmi_interop_hsa.h] Error 127
[ 30%] Building C object runtime/core/CMakeFiles/atmi_runtime.dir/atl_rt.c.o
make[1]: *** [CMakeFiles/Makefile2:298: runtime/interop/hsa/CMakeFiles/interop_header.dir/all] Error 2
/bin/sh: /usr/bin/rsync: No such file or directory
make[2]: *** [runtime/core/CMakeFiles/core_header.dir/build.make:62: include/atmi.h] Error 127
[ 32%] Building C object runtime/core/CMakeFiles/atmi_runtime.dir/atl_bindthread.c.o
make[1]: *** [CMakeFiles/Makefile2:188: runtime/core/CMakeFiles/core_header.dir/all] Error 2
[ 34%] Building C object runtime/core/CMakeFiles/atmi_runtime.dir/atl_profile.c.o
/bin/sh: /usr/bin/rsync: No such file or directory
make[2]: *** [device_runtime/CMakeFiles/device_header.dir/build.make:61: include/atmi_kl.h] Error 127
make[1]: *** [CMakeFiles/Makefile2:458: device_runtime/CMakeFiles/device_header.dir/all] Error 2